### PR TITLE
remove .as(Number.class) when ge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.malagu.linq</groupId>
 	<artifactId>linq</artifactId>
-	<version>1.1.1.RELEASE</version>
+	<version>1.1.2.RELEASE</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>语言集成查询工具</description>
 	<url>https://github.com/muxiangqiu/linq</url>

--- a/src/main/java/org/malagu/linq/lin/impl/LinImpl.java
+++ b/src/main/java/org/malagu/linq/lin/impl/LinImpl.java
@@ -325,7 +325,7 @@ public abstract class LinImpl<T extends Lin<T, Q>, Q extends CommonAbstractCrite
 		if (!beforeMethodInvoke()) {
 			return (T) this;
 		}
-		add(cb.ge(root.get(x).as(Number.class), y));
+		add(cb.ge(root.get(x), y));
 		return (T) this;
 	}
 	


### PR DESCRIPTION
解决在MSSQL下数字类型会被强制转化为 varbinary类型的bug。